### PR TITLE
Spelling and grammar corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The file path is interpreted relative to the workspace's root folder.
 
 otherwise...
 
-3. Settings are translated from your VS Code workspace/user setttings.
+3. Settings are translated from your VS Code workspace/user settings.
 4. Any open editor settings (indent spaces/tabs) for the specific file are merged in.
-5. Editorconfig settings are searched for (See http://editorconfig.org/) and are merged in.
+5. EditorConfig settings are searched for (See http://editorconfig.org/) and are merged in.
 
 ### VS Code | .jsbeautifyrc settings map:
 
@@ -46,9 +46,9 @@ extra_liners                  | html.format.extraLiners
 space_after_anon_function | javascript.format<br> .insertSpaceAfterFunctionKeywordForAnonymousFunctions
 space_in_paren | javascript.format<br> .insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis
 
-Note that the `html.format` settings will ONLY be used when the document is html. `javascript.format` settings are included always.
+Note that the `html.format` settings will ONLY be used when the document is HTML. `javascript.format` settings are always included.
 
-Also runs html and css beautify from the same package, as determined by the file extension. The schema indicates which beautifier each of the settings pertains to.
+Also runs HTML and CSS beautify from the same package, as determined by the file extension. The schema indicates which beautifier each of the settings pertains to.
 
 The `.jsbeautifyrc` config parser accepts sub elements of `html`, `js` and `css` so that different settings can be used for each of the beautifiers (like sublime allows). Note that this will cause the config file to be incorrectly structured for running `js-beautify` from the command line.
 
@@ -64,11 +64,11 @@ Settings are inherited from the base of the file. Thus:
 }
 ```
 
-Will result in the `indent_size` being set to 4 for Javascript and HTML, but set to 2 for CSS. All will get the same `indent_char` setting.
+Will result in the `indent_size` being set to 4 for JavaScript and HTML, but set to 2 for CSS. All will get the same `indent_char` setting.
 
 If the file is unsaved, or the type is undetermined, you'll be prompted for which beautifier to use.
 
-You can contol which file types, extensions, or specific file names should be beautified with the `beautify.language` setting.
+You can control which file types, extensions, or specific file names should be beautified with the `beautify.language` setting.
 
 ```javascript
 {

--- a/extension.js
+++ b/extension.js
@@ -185,7 +185,7 @@ const applyEdits = (editor, ranges, edits) => {
 	if (ranges.length !== edits.length) {
 		console.log("FAILED:", ranges.length, edits.length, ":failed");
 		vscode.window.showInformationMessage(
-			"Beautify ranges didin't get back the right number of edits");
+			"Beautify ranges didn't get back the right number of edits");
 		throw "";
 	}
 	return editor.edit(editorEdit => {


### PR DESCRIPTION
Only affect documentation, does not affect functionality, minor issues.

`extension.js` corrections:
- "Beautify ranges ~didin't~**didn't** get back the right number of edits" - line 188

`README.md` corrections:
- "Settings are translated from your VS Code workspace/user ~setttings~**settings**." - line 26
- "~Editorconfig~**EditorConfig** settings are searched for (See http://editorconfig.org/) and are merged in. - line 28
- "Note that the `html.format` settings will ONLY be used when the document is ~html~**HTML**. `javascript.format` settings are ~included always~**always included**." - line 67
- "Also runs ~html~**HTML** and ~css~**CSS** beautify from the same package, as determined by the file extension. The schema indicates which beautifier each of the settings pertains to." - line 51
- "Will result in the `indent_size` being set to 4 for ~Javascript~**JavaScript** and HTML, but set to 2 for CSS. All will get the same `indent_char` setting." - line 67
- "You can ~contol~**control** which file types, extensions, or specific file names should be beautified with the `beautify.language` setting." - Line 71