### PR TITLE
[Discussion] Restricting formatting to local files

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -137,19 +137,19 @@ class Formatters {
 			// dispose of the current
 			let selector = [];
 			if (Array.isArray(cfg[a])) {
-				selector = [].concat(cfg[a]);
+				selector = [].concat(cfg[a].map(language => ({ language, scheme: 'file' })));
 			} else {
 				for (let b in cfg[a]) {
 					let adder;
 					switch (b) {
 						case 'type':
-							adder = cfg[a][b];
+							adder = cfg[a][b].map(language => ({ language, scheme: 'file' }));
 							break;
 						case 'ext':
-							adder = [{ pattern: `**/*.{${cfg[a][b].join(',')}}` }];
+							adder = [{ pattern: `**/*.{${cfg[a][b].join(',')}}`, scheme: 'file' }];
 							break;
 						case 'filename':
-							adder = [{ pattern: `**/{${cfg[a][b].join(',')}}` }];
+							adder = [{ pattern: `**/{${cfg[a][b].join(',')}}`, scheme: 'file' }];
 							break;
 						default:
 							continue;


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services, this PR simply updates the current `DocumentSelector` to be limited to local files. This way, when someone has the Beautify extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their formatting will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with). This change shouldn't have an impact of existing Beautify usage, and is effectively a more explicit version of the current behavior.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*