### PR TITLE
feat: honor html.format.wrapAttributes setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ eol                           | files.eol
 tab_size                      | editor.tabSize
 indent_with_tabs&nbsp;_(inverted)_ | editor.insertSpaces
 wrap_line_length              | html.format.wrapLineLength
+wrap_attributes               | html.format.wrapAttributes
 unformatted                   | html.format.unformatted
 indent_inner_html             | html.format.indentInnerHtml
 preserve_newlines             | html.format.preserveNewLines

--- a/options.js
+++ b/options.js
@@ -66,6 +66,7 @@ const optionsFromVSCode = (doc, formattingOptions, type) => {
 		options.indent_inner_html = config.html.format.indentInnerHtml;
 		options.max_preserve_newlines = config.html.format.maxPreserveNewLines;
 		options.preserve_newlines = config.html.format.preserveNewLines;
+		options.wrap_attributes = config.html.format.wrapAttributes;
 
 		if (typeof config.html.format.unformatted === 'string') {
 			options.unformatted = config.html.format.unformatted


### PR DESCRIPTION
So it looks like for whatever reason the html.format.wrapAttributes settings are not being honored and this has been driving me crazy.

Microsoft/vscode#2204

I've been doing things like:
https://github.com/Microsoft/vscode/issues/2204#issuecomment-338796517

Or I have to add a `.jsbeautifyrc` with the `wrap_attributes` setting in it for this setting to be honored: 

https://github.com/Microsoft/vscode/issues/2204#issuecomment-262018163

Manually made the edit in my extensions folder and now this:

![image](https://user-images.githubusercontent.com/4655972/44124049-3a745f50-9ff9-11e8-8f0b-f2e84725a83a.png)

Becomes this:

![image](https://user-images.githubusercontent.com/4655972/44124070-58a948a0-9ff9-11e8-910a-ef72340bb7b9.png)

With this:

![image](https://user-images.githubusercontent.com/4655972/44124088-66bc0018-9ff9-11e8-86f5-5c1099eb1090.png)

😄 