### PR TITLE
Update js-beautify to 1.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+### 1.4.7: 20 Oct 2018
+* Update to version 1.8.8 of `js-beautify`
+
 ### 1.4.6: 17 Oct 2018
-* Update to version 1.8.6 of `js-beautify`
+* Update to version 1.8.7 of `js-beautify`
 * Add `space_after_named_function` details
 
 ### 1.4.4: 21 Sep 2018

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
   },
   "dependencies": {
     "editorconfig": "0.15.0",
-    "js-beautify": "^1.8.7",
+    "js-beautify": "^1.8.8",
     "minimatch": "^3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi @HookyQR,
please launch the 1.4.7 version of VSCode Extension.
I have updated the js-beautify lib to 1.8.8 that fixes [issue 1573](https://github.com/beautify-web/js-beautify/issues/1573).
Please, this is really annoying me and my team to use `async`. 