### PR TITLE
Feature fixes for js-beautify v1.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
             },
             "css": [
               "css",
+              "less",
               "scss"
             ],
             "html": [

--- a/schema/beautifyrc.json
+++ b/schema/beautifyrc.json
@@ -111,7 +111,7 @@
           "description": "Wrap attributes to new lines. [HTML]",
           "type": "string",
           "default": "auto",
-          "enum": ["auto", "force", "force-aligned", "force-expand-multiline", "align-multiple"]
+          "enum": ["auto", "force", "force-aligned", "force-expand-multiline", "align-multiple", "preserve", "preserve-aligned"]
         },
         "wrap_attributes_indent_size": {
           "description": "Indent wrapped attributes to after N characters. Defaults to 'indent_size'. [HTML]",


### PR DESCRIPTION
1. `less` is also supported in js-beautify. see [js-beautify/search?q=less](https://github.com/beautify-web/js-beautify/search?q=less)
2. Add preserve and preserve_align to html: https://github.com/beautify-web/js-beautify/commit/c413de0ef72a4458bd2519758942528c921f340e