### PR TITLE
Add support for Django HTML templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
             ],
             "html": [
               "htm",
-              "html"
+              "html",
+              "django-html"
             ]
           },
           "properties": {


### PR DESCRIPTION
Django HTML templates are activated while using vscode-django extension