### PR TITLE
Change `beautify.ignore` scope to resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+### 1.4.9: 01 Feb 2019
+* Change `beautify.ignore` scope to resource to enable folder configurations in multi-root workspaces to set their own ignored files.
+
 ### 1.4.8: 01 Feb 2019
 * Add `less` to default config `beautify.language.css`
 * Fix issue #284 correctly convert VSCode `html.format.extraLiners`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can control which file types, extensions, or specific file names should be b
 
 Beautify on save will be enabled when `"editor.formatOnSave"` is true.
 
-Beautification on particular files using the built in **Format Document** (which includes formatting on save) can be skipped with the `beautify.ignore` option. Using the `Beautify file` and `Beautify selection` will still work. For files opened from within the workspace directory, the glob patterns will match from the workspace root(s?). For files opened from elsewhere, or when no workspace is open, the patterns will match from the system root.
+Beautification on particular files using the built in **Format Document** (which includes formatting on save) can be skipped with the `beautify.ignore` option. Using the `Beautify file` and `Beautify selection` will still work. For files opened from within the workspace directory, the glob patterns will match from the workspace folder root. For files opened from elsewhere, or when no workspace is open, the patterns will match from the system root.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can control which file types, extensions, or specific file names should be b
 
 Beautify on save will be enabled when `"editor.formatOnSave"` is true.
 
-Beautification on particular files using the built in **Format Document** (which includes formatting on save) can be skipped with the `beautify.ignore` option. Using the `Beautify file` and `Beautify selection` will still work. For files opened from within the workspace directory, the glob patterns will match from the workspace root. For files opened from elsewhere, or when no workspace is open, the patterns will match from the system root.
+Beautification on particular files using the built in **Format Document** (which includes formatting on save) can be skipped with the `beautify.ignore` option. Using the `Beautify file` and `Beautify selection` will still work. For files opened from within the workspace directory, the glob patterns will match from the workspace root(s?). For files opened from elsewhere, or when no workspace is open, the patterns will match from the system root.
 
 Examples:
 

--- a/extension.js
+++ b/extension.js
@@ -195,7 +195,7 @@ class Formatters {
 }
 
 const formatters = new Formatters();
-formatters.configureWorkspace();
+formatters.configure();
 
 const applyEdits = (editor, ranges, edits) => {
   if (ranges.length !== edits.length) {

--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,7 @@ const getWorkspaceRoot = doc => {
 function fullEdit(type, doc, formattingOptions) {
   let name = doc.fileName;
   let base = getWorkspaceRoot(doc) || vscode.workspace.rootPath || '';
-  let ignore = vscode.workspace.getConfiguration('beautify')
+  let ignore = vscode.workspace.getConfiguration('beautify',doc.uri)
     .ignore;
   if (!Array.isArray(ignore)) ignore = [ignore];
   if (base && name.startsWith(base)) name = path.relative(base, name);
@@ -195,7 +195,7 @@ class Formatters {
 }
 
 const formatters = new Formatters();
-formatters.configure();
+formatters.configureWorkspace();
 
 const applyEdits = (editor, ranges, edits) => {
   if (ranges.length !== edits.length) {

--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,7 @@ const getWorkspaceRoot = doc => {
 function fullEdit(type, doc, formattingOptions) {
   let name = doc.fileName;
   let base = getWorkspaceRoot(doc) || vscode.workspace.rootPath || '';
-  let ignore = vscode.workspace.getConfiguration('beautify',doc.uri)
+  let ignore = vscode.workspace.getConfiguration('beautify', doc.uri)
     .ignore;
   if (!Array.isArray(ignore)) ignore = [ignore];
   if (base && name.startsWith(base)) name = path.relative(base, name);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "beautify",
   "displayName": "Beautify",
   "description": "Beautify code in place for VS Code",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "publisher": "HookyQR",
   "engines": {
     "vscode": "^1.22.0"
@@ -64,7 +64,8 @@
             "type": "string"
           },
           "default": [],
-          "description": "List of paths to ignore when using VS Code format command, including format on save. Uses glob pattern matching."
+          "description": "List of paths to ignore when using VS Code format command, including format on save. Uses glob pattern matching.",
+          "scope": "resource"
         },
         "beautify.config": {
           "type": [


### PR DESCRIPTION
This is a simple change to enable folder configurations in multi-root workspaces to set their own ignored files. It's pretty air-weight, especially since you're already calling getConfiguration on the workspace. If you incorporate that it would save me a lot of headaches in onboarding new teammembers and such.